### PR TITLE
Added ‘appsupport’ to NSApplicationSupportDirectory scheme mapping

### DIFF
--- a/Classy/Parser/CASStyleProperty.m
+++ b/Classy/Parser/CASStyleProperty.m
@@ -233,6 +233,8 @@
             searchMask = NSCachesDirectory;
         } else if([scheme isEqualToString:@"documents"]) {
             searchMask = NSDocumentDirectory;
+        } else if([scheme isEqualToString:@"appsupport"]) {
+            searchMask = NSApplicationSupportDirectory;
         }
         
         if(searchMask != 0) {


### PR DESCRIPTION
Since Classy already have support for documents and caches, i think application support was missing.
