### PR TITLE
fix: some parameters ('class') incompatible to objc++ compilation (convention met)

### DIFF
--- a/Classy/Parser/CASStyler.h
+++ b/Classy/Parser/CASStyler.h
@@ -46,7 +46,7 @@
 /**
  *  Returns a cached CASObjectClassDescriptor if it exists or creates one
  */
-- (CASObjectClassDescriptor *)objectClassDescriptorForClass:(Class)class_;
+- (CASObjectClassDescriptor *)objectClassDescriptorForClass:(Class)aClass;
 
 /**
  *  Schedule update for styleable item.

--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -128,8 +128,8 @@
 
 #pragma mark - private
 
-- (NSArray *)invocationsForClass:(Class)class_ styleProperty:(CASStyleProperty *)styleProperty keyPath:(NSString *)keypath {
-    CASObjectClassDescriptor *objectClassDescriptor = [self objectClassDescriptorForClass:class_];
+- (NSArray *)invocationsForClass:(Class)aClass styleProperty:(CASStyleProperty *)styleProperty keyPath:(NSString *)keypath {
+    CASObjectClassDescriptor *objectClassDescriptor = [self objectClassDescriptorForClass:aClass];
     CASPropertyDescriptor *propertyDescriptor = [objectClassDescriptor propertyDescriptorForKey:styleProperty.name];
 
     //Special case textAttributes
@@ -554,14 +554,14 @@
     [objectClassDescriptor setArgumentDescriptors:@[colorArg] forPropertyKey:@cas_propertykey(NSShadow, shadowColor)];
 }
 
-- (CASObjectClassDescriptor *)objectClassDescriptorForClass:(Class)class_ {
-    CASObjectClassDescriptor *objectClassDescriptor = [self.objectClassDescriptorCache objectForKey:class_];
+- (CASObjectClassDescriptor *)objectClassDescriptorForClass:(Class)aClass {
+    CASObjectClassDescriptor *objectClassDescriptor = [self.objectClassDescriptorCache objectForKey:aClass];
     if (!objectClassDescriptor) {
-        objectClassDescriptor = [[CASObjectClassDescriptor alloc] initWithClass:class_];
-        if (class_.superclass && ![NSObject.class isSubclassOfClass:class_.superclass] && ![UIResponder.class isSubclassOfClass:class_.superclass]) {
-            objectClassDescriptor.parent = [self objectClassDescriptorForClass:class_.superclass];
+        objectClassDescriptor = [[CASObjectClassDescriptor alloc] initWithClass:aClass];
+        if (aClass.superclass && ![NSObject.class isSubclassOfClass:aClass.superclass] && ![UIResponder.class isSubclassOfClass:aClass.superclass]) {
+            objectClassDescriptor.parent = [self objectClassDescriptorForClass:aClass.superclass];
         }
-        [self.objectClassDescriptorCache setObject:objectClassDescriptor forKey:class_];
+        [self.objectClassDescriptorCache setObject:objectClassDescriptor forKey:aClass];
     }
     return objectClassDescriptor;
 }

--- a/Classy/Reflection/CASArgumentDescriptor.h
+++ b/Classy/Reflection/CASArgumentDescriptor.h
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSUInteger, CASPrimitiveType) {
 
 + (instancetype)argWithObjCType:(const char *)type;
 + (instancetype)argWithType:(NSString *)type;
-+ (instancetype)argWithClass:(Class)class_;
++ (instancetype)argWithClass:(Class)aClass;
 + (instancetype)argWithValuesByName:(NSDictionary *)valuesByName;
 + (instancetype)argWithName:(NSString *)name valuesByName:(NSDictionary *)valuesByName;
 

--- a/Classy/Reflection/CASArgumentDescriptor.m
+++ b/Classy/Reflection/CASArgumentDescriptor.m
@@ -32,9 +32,9 @@
     return descriptor;
 }
 
-+ (instancetype)argWithClass:(Class)class_ {
++ (instancetype)argWithClass:(Class)aClass {
     CASArgumentDescriptor *descriptor = CASArgumentDescriptor.new;
-    descriptor.argumentClass = class_;
+    descriptor.argumentClass = aClass;
     return descriptor;
 }
 

--- a/Classy/Reflection/CASObjectClassDescriptor.h
+++ b/Classy/Reflection/CASObjectClassDescriptor.h
@@ -26,7 +26,7 @@
  */
 @property (nonatomic, strong) NSDictionary *propertyKeyAliases;
 
-- (id)initWithClass:(Class)class_;
+- (id)initWithClass:(Class)aClass;
 
 - (NSInvocation *)invocationForPropertyDescriptor:(CASPropertyDescriptor *)propertyDescriptor;
 

--- a/Classy/Reflection/CASObjectClassDescriptor.m
+++ b/Classy/Reflection/CASObjectClassDescriptor.m
@@ -20,11 +20,11 @@
 
 @implementation CASObjectClassDescriptor
 
-- (id)initWithClass:(Class)class_ {
+- (id)initWithClass:(Class)aClass {
     self = [super init];
     if (!self) return nil;
 
-    self.objectClass = class_;
+    self.objectClass = aClass;
     self.propertyDescriptorCache = NSMutableDictionary.new;
 
     return self;


### PR DESCRIPTION
quick fix for objc++ compilation issues.

when trying to use classy in a project including objective-c++ files (.mm extension) there are parameter names which conflict with C/C++ keywords (i.e. 'class').
