### PR TITLE
Added support for [UIButton setImage:forState:]

### DIFF
--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -412,6 +412,10 @@
     [objectClassDescriptor setArgumentDescriptors:@[colorArg, stateArg] setter:@selector(setTitleShadowColor:forState:) forPropertyKey:@"titleShadowColor"];
 
     [objectClassDescriptor setArgumentDescriptors:@[imageArg, stateArg] setter:@selector(setBackgroundImage:forState:) forPropertyKey:@"backgroundImage"];
+    
+    [objectClassDescriptor setArgumentDescriptors:@[imageArg, stateArg] setter:@selector(setImage:forState:) forPropertyKey:@"image"];
+    
+    
 
     // UIBarButtonItem
     objectClassDescriptor = [self objectClassDescriptorForClass:UIBarButtonItem.class];


### PR DESCRIPTION
I suppose this was removed by mistake or never implemented.
Anyways, now is it possible to set UIButton image, same way as background image.

UIButton{
    image[state:normal]: $someImageVarName;
}
