### PR TITLE
UITextFieldViewMode for UITextFieldView

### DIFF
--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -386,6 +386,15 @@
     };
     [objectClassDescriptor setArgumentDescriptors:@[[CASArgumentDescriptor argWithValuesByName:borderStyleMap]] forPropertyKey:@cas_propertykey(UITextField, borderStyle)];
 
+    NSDictionary *textFieldViewModeMap = @{
+                                           @"never"           : @(UITextFieldViewModeNever),
+                                           @"whileEditing"    : @(UITextFieldViewModeWhileEditing),
+                                           @"unlessEditing"   : @(UITextFieldViewModeUnlessEditing),
+                                           @"always"          : @(UITextFieldViewModeAlways),
+                                           };
+    [objectClassDescriptor setArgumentDescriptors:@[[CASArgumentDescriptor argWithValuesByName:textFieldViewModeMap]] forPropertyKey:@cas_propertykey(UITextField, leftViewMode)];
+    [objectClassDescriptor setArgumentDescriptors:@[[CASArgumentDescriptor argWithValuesByName:textFieldViewModeMap]] forPropertyKey:@cas_propertykey(UITextField, rightViewMode)];
+    [objectClassDescriptor setArgumentDescriptors:@[[CASArgumentDescriptor argWithValuesByName:textFieldViewModeMap]] forPropertyKey:@cas_propertykey(UITextField, clearButtonMode)];
     
     // UIControl
     objectClassDescriptor = [self objectClassDescriptorForClass:UIControl.class];


### PR DESCRIPTION
I added UITextFieldViewMode enum map for the properties leftViewMode, rightViewMode and clearButtonMode on UITextFieldView.

I think this should be in there as the right/leftViews are kind of decorative, so you should be able to set the view modes from the stylesheet.

Let me know what you think.

Cheers
