### PR TITLE
Fix for my PR that broke the multiple style class functionality

### DIFF
--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -92,8 +92,9 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     Class class = [item class];
     [possibleStyleNodes addObjectsFromArray:[self.objectClassIndex valueForKey:NSStringFromClass(class)]];
     
-    if (item.cas_styleClass) {
-        [possibleStyleNodes addObjectsFromArray:[self.styleClassIndex valueForKey:item.cas_styleClass]];
+    NSArray *styleClasses = [item.cas_styleClass componentsSeparatedByString:CASStyleClassSeparator];
+    for (NSString *styleClass in styleClasses.reverseObjectEnumerator) {
+        [possibleStyleNodes addObjectsFromArray:[self.styleClassIndex valueForKey:styleClass]];
     }
     
     for (CASStyleNode *styleNode in possibleStyleNodes) {
@@ -207,10 +208,11 @@ NSArray *ClassGetSubclasses(Class parentClass) {
 - (void)populateStyleLookupTables:(NSArray *)styleNodes {
     for (CASStyleNode *styleNode in styleNodes) {
         if (styleNode.styleSelector.styleClass) {
-            if (![self.styleClassIndex valueForKey:styleNode.styleSelector.styleClass]) {
-                [self.styleClassIndex setValue:[@[] mutableCopy] forKey:styleNode.styleSelector.styleClass];
+            NSString *styleClassKey = styleNode.styleSelector.styleClass;
+            if (![self.styleClassIndex valueForKey:styleClassKey]) {
+                [self.styleClassIndex setValue:[@[] mutableCopy] forKey:styleClassKey];
             }
-            [[self.styleClassIndex valueForKey:styleNode.styleSelector.styleClass] addObject:styleNode];
+            [[self.styleClassIndex valueForKey:styleClassKey] addObject:styleNode];
         } else {
             
             Class class = styleNode.styleSelector.objectClass;

--- a/Tests/ClassyTests.xcodeproj/project.pbxproj
+++ b/Tests/ClassyTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4ED0F9A3198B476E00C9FE2C /* UIKit-MultipleClasses.cas in Resources */ = {isa = PBXBuildFile; fileRef = 4ED0F9A1198B465600C9FE2C /* UIKit-MultipleClasses.cas */; };
 		9980D2916D344434ACF1CB78 /* libPods-ClassyTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C594C855E67D4ABAAB9D8034 /* libPods-ClassyTests.a */; };
 		BDABE4F7F7AD42D589D779BD /* libPods-ClassyTestsLoader.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 13B648C088D7485783343464 /* libPods-ClassyTestsLoader.a */; };
 		DD10AD361819FA6800A5B71D /* CustomView-Basic.cas in Resources */ = {isa = PBXBuildFile; fileRef = DD10AD2E1819FA6800A5B71D /* CustomView-Basic.cas */; };
@@ -75,6 +76,7 @@
 /* Begin PBXFileReference section */
 		13B648C088D7485783343464 /* libPods-ClassyTestsLoader.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ClassyTestsLoader.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		34BACA8D71A54943A4505935 /* Pods-ClassyTestsLoader.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClassyTestsLoader.xcconfig"; path = "../Pods/Pods-ClassyTestsLoader.xcconfig"; sourceTree = "<group>"; };
+		4ED0F9A1198B465600C9FE2C /* UIKit-MultipleClasses.cas */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "UIKit-MultipleClasses.cas"; sourceTree = "<group>"; };
 		5548B765C39C4F0FA776C911 /* Pods-ClassyTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ClassyTests.xcconfig"; path = "../Pods/Pods-ClassyTests.xcconfig"; sourceTree = "<group>"; };
 		C594C855E67D4ABAAB9D8034 /* libPods-ClassyTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ClassyTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD10AD2E1819FA6800A5B71D /* CustomView-Basic.cas */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "CustomView-Basic.cas"; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 				DDB16C991895563900256EC6 /* Injected-File.cas */,
 				DDE7E51D18915B0600BA5718 /* Precedence-1.cas */,
 				DDE7E51E18915B0600BA5718 /* Precedence-2.cas */,
+				4ED0F9A1198B465600C9FE2C /* UIKit-MultipleClasses.cas */,
 			);
 			path = Stylesheets;
 			sourceTree = "<group>";
@@ -408,6 +411,7 @@
 				DD5B2DB0189532DC00CB6531 /* Variables-Injection.cas in Resources */,
 				DDE7E52018915B0600BA5718 /* Precedence-2.cas in Resources */,
 				DD10AD391819FA6800A5B71D /* Selectors-Complex.cas in Resources */,
+				4ED0F9A3198B476E00C9FE2C /* UIKit-MultipleClasses.cas in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Tests/Specs/Integration Tests/CASUIKitSpec.m
+++ b/Tests/Specs/Integration Tests/CASUIKitSpec.m
@@ -54,4 +54,18 @@ SpecBegin(CASUIKit)
     expect(view.background.capInsets).to.equal(UIEdgeInsetsMake(1, 2, 3, 4));
 }
 
+- (void)testMultipleStyleClasses {
+    CASStyler *styler = CASStyler.new;
+    styler.filePath = [[NSBundle bundleForClass:self.class] pathForResource:@"UIKit-MultipleClasses.cas" ofType:nil];
+    UIView *view = UIView.new;
+    view.cas_styleClass = @"class1";
+    [view cas_addStyleClass:@"class2"];
+    [styler styleItem:view];
+    expect(view.backgroundColor).to.equal([UIColor redColor]);
+    expect(view.layer.cornerRadius).to.equal(2);
+    [view cas_addStyleClass:@"class3"];
+    [styler styleItem:view];
+    expect(view.backgroundColor).to.equal([UIColor greenColor]);
+}
+
 SpecEnd

--- a/Tests/Stylesheets/UIKit-MultipleClasses.cas
+++ b/Tests/Stylesheets/UIKit-MultipleClasses.cas
@@ -1,0 +1,13 @@
+UIView.class1 {
+    background-color: red;
+}
+
+UIView.class2 {
+    layer: @{
+        corner-radius: 2;
+    }
+}
+
+UIView.class3 {
+    background-color: green;
+}


### PR DESCRIPTION
fixes #67 

The problem was when looking up possible style nodes from the dictionary we weren't accounting for the case of multiple style classes on a view. Now we loop through all style classes on a view and lookup the matching style nodes for each class.
