### PR TITLE
Adding support for selected|highlighted state

### DIFF
--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -384,10 +384,11 @@ NSArray *ClassGetSubclasses(Class parentClass) {
 
     // Common ENUM maps
     NSDictionary *controlStateMap = @{
-        @"normal"       : @(UIControlStateNormal),
-        @"highlighted"  : @(UIControlStateHighlighted),
-        @"disabled"     : @(UIControlStateDisabled),
-        @"selected"     : @(UIControlStateSelected),
+        @"normal"               : @(UIControlStateNormal),
+        @"highlighted"          : @(UIControlStateHighlighted),
+        @"disabled"             : @(UIControlStateDisabled),
+        @"selected"             : @(UIControlStateSelected),
+        @"selectedHighlighted"  : @(UIControlStateSelected|UIControlStateHighlighted)
     };
 
     NSDictionary *textAlignmentMap = @{


### PR DESCRIPTION
Based off of this slack post.   There is a distinct difference between UIControlStateHighlighted and UIControlStateSelected|UIControlStateHighlighted.

http://stackoverflow.com/questions/16907166/uibutton-highlighted-state-not-showing-when-clicking-over-a-selected-uibutton