### PR TITLE
Fix for UIBarButtonItems not being styled in time

### DIFF
--- a/Classy.xcworkspace/contents.xcworkspacedata
+++ b/Classy.xcworkspace/contents.xcworkspacedata
@@ -191,6 +191,12 @@
          <FileRef
             location = "group:UISlider+CASAdditions.m">
          </FileRef>
+         <FileRef
+            location = "group:UINavigationItem+CASAdditions.h">
+         </FileRef>
+         <FileRef
+            location = "group:UINavigationItem+CASAdditions.m">
+         </FileRef>
       </Group>
       <Group
          location = "group:Reflection"

--- a/Classy/Additions/UINavigationItem+CASAdditions.h
+++ b/Classy/Additions/UINavigationItem+CASAdditions.h
@@ -1,0 +1,13 @@
+//
+//  UINavigationItem+CASAdditions.h
+//  
+//
+//  Created by Joseph Ridenour on 1/21/15.
+//
+//
+
+#import <UIKit/UIKit.h>
+
+@interface UINavigationItem (CASAdditions)
+
+@end

--- a/Classy/Additions/UINavigationItem+CASAdditions.m
+++ b/Classy/Additions/UINavigationItem+CASAdditions.m
@@ -1,0 +1,48 @@
+//
+//  UINavigationItem+CASAdditions.m
+//  
+//
+//  Created by Joseph Ridenour on 1/21/15.
+//
+//
+
+#import "UINavigationItem+CASAdditions.h"
+#import "CASStyler.h"
+#import "UIBarItem+CASAdditions.h"
+#import "NSObject+CASSwizzle.h"
+
+@implementation UINavigationItem (CASAdditions)
+
++ (void)load {
+    [self cas_swizzleInstanceSelector:@selector(setRightBarButtonItem:animated:) withNewSelector:@selector(cas_setRightBarButtonItem:animated:)];
+    [self cas_swizzleInstanceSelector:@selector(setLeftBarButtonItem:animated:) withNewSelector:@selector(cas_setLeftBarButtonItem:animated:)];
+    
+    [self cas_swizzleInstanceSelector:@selector(setLeftBarButtonItems:animated:) withNewSelector:@selector(cas_setRightBarButtonItems:animated:)];
+    [self cas_swizzleInstanceSelector:@selector(setLeftBarButtonItems:animated:) withNewSelector:@selector(cas_setLeftBarButtonItems:animated:)];
+}
+
+- (void)cas_setRightBarButtonItem:(UIBarButtonItem *)item animated:(BOOL)animated {
+    [CASStyler.defaultStyler styleItem:item];
+    [self cas_setRightBarButtonItem:item animated:animated];
+}
+
+- (void)cas_setLeftBarButtonItem:(UIBarButtonItem *)item animated:(BOOL)animated {
+    [CASStyler.defaultStyler styleItem:item];
+    [self cas_setLeftBarButtonItem:item animated:animated];
+}
+
+- (void)cas_setRightBarButtonItems:(NSArray *)items animated:(BOOL)animated {
+    [items enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [CASStyler.defaultStyler styleItem:obj];
+    }];
+    [self cas_setRightBarButtonItems:items animated:animated];
+}
+
+- (void)cas_setLeftBarButtonItems:(NSArray *)items animated:(BOOL)animated {
+    [items enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [CASStyler.defaultStyler styleItem:obj];
+    }];
+    [self cas_setLeftBarButtonItems:items animated:animated];
+}
+
+@end


### PR DESCRIPTION
A UIBarButtonItem that is being pushed onto a navigation stack does not get styled immediately.   The reason is the UINavigationBar is always on the screen, and doesn't get the didMoveToWindow method again,  so classy has no way of knowing that these items need styling.

With this fix whenever you set the item(s) on the UINavigationItem it will do the styling immediately.