### PR TITLE
Add 64Bit support for floats

### DIFF
--- a/Classy/Additions/CASStyleClassUtilities.h
+++ b/Classy/Additions/CASStyleClassUtilities.h
@@ -15,9 +15,9 @@
 
 + (void)setStyleClass:(NSString *)styleClass forItem:(id<CASStyleableItem>)item;
 
-+ (NSMutableSet *)styleClassesForItem:(id<CASStyleableItem>)item;
++ (NSMutableArray *)styleClassesForItem:(id<CASStyleableItem>)item;
 
-+ (void)setStyleClasses:(NSMutableSet *)styleClasses forItem:(id<CASStyleableItem>)item;
++ (void)setStyleClasses:(NSMutableArray *)styleClasses forItem:(id<CASStyleableItem>)item;
 
 + (void)addStyleClass:(NSString *)styleClass forItem:(id<CASStyleableItem>)item;
 

--- a/Classy/Additions/CASStyleClassUtilities.m
+++ b/Classy/Additions/CASStyleClassUtilities.m
@@ -16,13 +16,13 @@ static void *CASStyleClassesKey = &CASStyleClassesKey;
 @implementation CASStyleClassUtilities
 
 + (NSString *)styleClassForItem:(id<CASStyleableItem>)item {
-    NSMutableSet *styleClasses = [self styleClassesForItem:item];
-    return [styleClasses.allObjects componentsJoinedByString:CASStyleClassSeparator];
+    NSMutableArray *styleClasses = [self styleClassesForItem:item];
+    return [styleClasses componentsJoinedByString:CASStyleClassSeparator];
 }
 
 + (void)setStyleClass:(NSString *)styleClass forItem:(id<CASStyleableItem>)item {
     NSArray *classCandidates = [styleClass componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
-    NSMutableSet *styleClasses = [self styleClassesForItem:item];
+    NSMutableArray *styleClasses = [self styleClassesForItem:item];
     [styleClasses removeAllObjects];
 
     if (!classCandidates.count) {
@@ -30,7 +30,7 @@ static void *CASStyleClassesKey = &CASStyleClassesKey;
         return;
     }
     if (!styleClasses) {
-        styleClasses = [NSMutableSet set];
+        styleClasses = [NSMutableArray array];
         [self setStyleClasses:styleClasses forItem:item];
     }
     for (NSString *styleClass in classCandidates) {
@@ -40,20 +40,20 @@ static void *CASStyleClassesKey = &CASStyleClassesKey;
     }
 }
 
-+ (NSMutableSet *)styleClassesForItem:(id<CASStyleableItem>)item {
++ (NSMutableArray *)styleClassesForItem:(id<CASStyleableItem>)item {
     return objc_getAssociatedObject(item, CASStyleClassesKey);
 }
 
-+ (void)setStyleClasses:(NSMutableSet *)styleClasses forItem:(id<CASStyleableItem>)item {
++ (void)setStyleClasses:(NSMutableArray *)styleClasses forItem:(id<CASStyleableItem>)item {
     objc_setAssociatedObject(item, CASStyleClassesKey, styleClasses, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 }
 
 + (void)addStyleClass:(NSString *)styleClass forItem:(id<CASStyleableItem>)item {
     if (![styleClass isKindOfClass:NSString.class] || !styleClass.length) return;
 
-    NSMutableSet *styleClasses = [self styleClassesForItem:item];
+    NSMutableArray *styleClasses = [self styleClassesForItem:item];
     if (!styleClasses) {
-        styleClasses = [NSMutableSet set];
+        styleClasses = [NSMutableArray array];
         [self setStyleClasses:styleClasses forItem:item];
     }
     [styleClasses addObject:styleClass];
@@ -62,7 +62,7 @@ static void *CASStyleClassesKey = &CASStyleClassesKey;
 + (void)removeStyleClass:(NSString *)styleClass forItem:(id<CASStyleableItem>)item {
     if (![styleClass isKindOfClass:NSString.class] || !styleClass.length) return;
 
-    NSMutableSet *styleClasses = [self styleClassesForItem:item];
+    NSMutableArray *styleClasses = [self styleClassesForItem:item];
     [styleClasses removeObject:styleClass];
 }
 

--- a/Classy/Additions/UIColor+CASAdditions.m
+++ b/Classy/Additions/UIColor+CASAdditions.m
@@ -82,7 +82,7 @@
     
     // Add alpha
     if (hex && includeAlpha) {
-        hex = [hex stringByAppendingFormat:@"%02x", (NSUInteger)(CGColorGetAlpha(self.CGColor) * 255.0f)];
+        hex = [hex stringByAppendingFormat:@"%02lx", (unsigned long)(CGColorGetAlpha(self.CGColor) * 255.0f)];
     }
     
     // Unsupported color space

--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -287,6 +287,11 @@ NSArray *ClassGetSubclasses(Class parentClass) {
                 [invocation setArgument:&value atIndex:argIndex];
                 break;
             }
+            case CASPrimitiveTypeFloat: {
+                float value = [[styleProperty valueOfTokenType:CASTokenTypeUnit] floatValue];
+                [invocation setArgument:&value atIndex:argIndex];
+                break;
+            }
             case CASPrimitiveTypeCGSize: {
                 CGSize size;
                 [styleProperty transformValuesToCGSize:&size];

--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -93,7 +93,8 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     [possibleStyleNodes addObjectsFromArray:[self.objectClassIndex valueForKey:NSStringFromClass(class)]];
     
     NSArray *styleClasses = [item.cas_styleClass componentsSeparatedByString:CASStyleClassSeparator];
-    for (NSString *styleClass in styleClasses.reverseObjectEnumerator) {
+    
+    for (NSString *styleClass in styleClasses) {
         [possibleStyleNodes addObjectsFromArray:[self.styleClassIndex valueForKey:styleClass]];
     }
     

--- a/Classy/Reflection/CASArgumentDescriptor.h
+++ b/Classy/Reflection/CASArgumentDescriptor.h
@@ -15,6 +15,7 @@ typedef NS_ENUM(NSUInteger, CASPrimitiveType) {
     CASPrimitiveTypeNone,
     CASPrimitiveTypeUnsupported,
     CASPrimitiveTypeBOOL,
+    CASPrimitiveTypeFloat,
     CASPrimitiveTypeDouble,
     CASPrimitiveTypeInteger,
     CASPrimitiveTypeCGPoint,

--- a/Classy/Reflection/CASArgumentDescriptor.m
+++ b/Classy/Reflection/CASArgumentDescriptor.m
@@ -72,11 +72,12 @@
     if (isInteger) return CASPrimitiveTypeInteger;
 
     // check for double
-    BOOL isDouble = self.type.length == 1 && (
-           [self.type isEqualToString:@"f"]   // A float
-        || [self.type isEqualToString:@"d"]); // A double
-    if (isDouble) return CASPrimitiveTypeDouble;
-
+    if ([self.type isEqualToString:@"f"]) {
+        return CASPrimitiveTypeFloat;
+    } else if ([self.type isEqualToString:@"d"]) {
+        return CASPrimitiveTypeDouble;
+    }
+    
     // check for structs
     if ([self.type hasPrefix:@"{CGSize"]) {
         return CASPrimitiveTypeCGSize;

--- a/Example/ClassyExample/CASSimpleFormViewController.m
+++ b/Example/ClassyExample/CASSimpleFormViewController.m
@@ -26,6 +26,11 @@
 
 - (void)viewDidLoad {
     [super viewDidLoad];
+    
+    UIView *v = [[UIView alloc] initWithFrame:CGRectMake(100, 100, 100, 100)];
+    v.backgroundColor = [UIColor redColor];
+    v.cas_styleClass = @"shadow-view";
+    [self.view addSubview:v];
 }
 
 @end

--- a/Example/ClassyExample/Stylesheets/stylesheet.cas
+++ b/Example/ClassyExample/Stylesheets/stylesheet.cas
@@ -8,3 +8,11 @@ UITableView UILabel {
 ^UIViewController > UIView {
   background-color: blue;
 }
+
+UIView.shadow-view {
+    layer @
+        shadow-radius 10
+        shadow-opacity 1
+        shadow-color black
+        shadow-offset 0,0
+}

--- a/Tests/Specs/Integration Tests/CASUIAppearanceSpec.m
+++ b/Tests/Specs/Integration Tests/CASUIAppearanceSpec.m
@@ -248,6 +248,11 @@ SpecBegin(CASUIAppearance)
 
 - (void)testUITableViewCellAppearance {
     UITableViewCell *view = UITableViewCell.new;
+    
+    // In iOS8, layoutMargins affects our separatorInset
+    if ([view respondsToSelector:@selector(layoutMargins)]) {
+        [view setLayoutMargins:UIEdgeInsetsZero];
+    }
     [CASStyler.defaultStyler styleItem:view];
 
     //top and bottom are ignored

--- a/Tests/Specs/Integration Tests/CASUIAppearanceSpec.m
+++ b/Tests/Specs/Integration Tests/CASUIAppearanceSpec.m
@@ -251,7 +251,7 @@ SpecBegin(CASUIAppearance)
     
     // In iOS8, layoutMargins affects our separatorInset
     if ([view respondsToSelector:@selector(layoutMargins)]) {
-        [view setLayoutMargins:UIEdgeInsetsZero];
+        [view setValue:[NSValue valueWithUIEdgeInsets:UIEdgeInsetsZero] forKey:@"layoutMargins"];
     }
     [CASStyler.defaultStyler styleItem:view];
 

--- a/Tests/Specs/Unit Tests/CASArgumentDescriptorSpec.m
+++ b/Tests/Specs/Unit Tests/CASArgumentDescriptorSpec.m
@@ -30,8 +30,12 @@ SpecBegin(CASArgumentDescriptor)
 
 - (void)testReturnDouble {
     expect([CASArgumentDescriptor argWithObjCType:@encode(double)].primitiveType).to.equal(CASPrimitiveTypeDouble);
-    expect([CASArgumentDescriptor argWithObjCType:@encode(float)].primitiveType).to.equal(CASPrimitiveTypeDouble);
-    expect([CASArgumentDescriptor argWithObjCType:@encode(CGFloat)].primitiveType).to.equal(CASPrimitiveTypeDouble);
+    expect([CASArgumentDescriptor argWithObjCType:@encode(float)].primitiveType).to.equal(CASPrimitiveTypeFloat);
+    if (sizeof(void*) == 4) {
+        expect([CASArgumentDescriptor argWithObjCType:@encode(CGFloat)].primitiveType).to.equal(CASPrimitiveTypeFloat);
+    } else if (sizeof(void*) == 8) {
+        expect([CASArgumentDescriptor argWithObjCType:@encode(CGFloat)].primitiveType).to.equal(CASPrimitiveTypeDouble);
+    }
 }
 
 - (void)testReturnCGSize {

--- a/Tests/Specs/Unit Tests/UIView_CASAdditionsSpec.m
+++ b/Tests/Specs/Unit Tests/UIView_CASAdditionsSpec.m
@@ -52,8 +52,7 @@ SpecBegin(UIView_CASAdditions)
     expect(view.setNeedsUpdateStylingCount).to.equal(2);
 
     // Run the loop
-    [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
-                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
+    [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:1]];
 
     expect(view.updateStylingCount).to.equal(2);
     expect(view.setNeedsUpdateStylingCount).to.equal(2);


### PR DESCRIPTION
On 64Bit systems the doubleValue is being truncated when being sent to properties of 'float' type.   Example being CALayer.shadowOpacity.

This PR creates a dedicated primitive conversion for Float types to handle this truncation