### PR TITLE
Support for [UIFont preferredFontForTextStyle:]

### DIFF
--- a/Classy/Parser/CASStyleProperty.m
+++ b/Classy/Parser/CASStyleProperty.m
@@ -273,11 +273,37 @@
         return NO;
     }
 
-    CGFloat fontSizeValue = [fontSize floatValue] ?: [UIFont systemFontSize];
-    if (fontName) {
-        *font = [UIFont fontWithName:fontName size:fontSizeValue];
+    static NSDictionary *textStyleLookupMap = nil;
+    if (!textStyleLookupMap) {
+        // Classy is available also on iOS6, so instead of using UIKit consts for text styles that are available
+        // only on iOS7+ let the strings be hardcoded. This avoids the need for weak-linking UIKit.
+        textStyleLookupMap = @{
+                @"body" : @"UICTFontTextStyleBody",
+                @"caption1" : @"UICTFontTextStyleCaption1",
+                @"caption2" : @"UICTFontTextStyleCaption2",
+                @"footnote" : @"UICTFontTextStyleFootnote",
+                @"headline" : @"UICTFontTextStyleHeadline",
+                @"subheadline" : @"UICTFontTextStyleSubhead",
+        };
+    }
+
+    NSString *textStyle = textStyleLookupMap[fontName];
+    if (textStyle && !fontSize) {
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "UnavailableInDeploymentTarget"
+        if ([UIFont respondsToSelector:@selector(preferredFontForTextStyle:)]) {
+            *font = [UIFont preferredFontForTextStyle:textStyle];
+        } else {
+            return NO;
+        }
+#pragma clang diagnostic pop
     } else {
-        *font = [UIFont systemFontOfSize:fontSizeValue];
+        CGFloat fontSizeValue = [fontSize floatValue] ?: [UIFont systemFontSize];
+        if (fontName) {
+            *font = [UIFont fontWithName:fontName size:fontSizeValue];
+        } else {
+            *font = [UIFont systemFontOfSize:fontSizeValue];
+        }
     }
     return YES;
 }

--- a/Tests/Specs/Unit Tests/CASStylePropertySpec.m
+++ b/Tests/Specs/Unit Tests/CASStylePropertySpec.m
@@ -312,4 +312,27 @@ SpecBegin(CASStyleProperty)
     expect(image).toNot.beNil();
 }
 
+- (void)testFont {
+    NSArray *valueTokens = CASTokensFromString(@"\"Palatino\" 24");
+    
+    CASStyleProperty *prop = [[CASStyleProperty alloc]initWithNameToken:nil valueTokens:valueTokens];
+    __block UIFont *font = nil;
+    expect([prop transformValuesToUIFont:&font]).to.beTruthy();
+    expect(font.familyName).to.equal(@"Palatino");
+    expect(font.pointSize).to.equal(24.0f);
+}
+
+- (void)testPreferredFontForTextStyle {
+    NSArray *valueTokens = CASTokensFromString(@"body");
+    
+    CASStyleProperty *prop = [[CASStyleProperty alloc]initWithNameToken:nil valueTokens:valueTokens];
+    __block UIFont *font = nil;
+    if ([UIFont respondsToSelector:@selector(preferredFontForTextStyle:)]) {
+        expect([prop transformValuesToUIFont:&font]).to.beTruthy();
+        expect(font).to.equal([UIFont preferredFontForTextStyle:@"UICTFontTextStyleBody"]);
+    } else {
+        expect([prop transformValuesToUIFont:&font]).to.beFalsy();
+    }
+}
+
 SpecEnd


### PR DESCRIPTION
This PR adds ability to style font properties with values of `[UIFont preferredFontForTextStyle:]`.

To use it, instead of font name and size, use one of the following as font name:

* **body** for `UIFontTextStyleBody`
* **caption1** for `UIFontTextStyleCaption1`
* **caption2** for `UIFontTextStyleCaption1`
* **footnote** for `UIFontTextStyleFootnote`
* **headline**  for `UIFontTextStyleHeadline`
* **subheadline** for `UIFontTextStyleSubheadline`

So instead
```
UILabel {
  font: "Helvetica" 14;
}
```

you use
```
UILabel {
  font: body;
}
```

On iOS6, the fonts will not be recognized, so you should use media queries.