### PR TITLE
Make the cas_styleClass IBInspectable so it can be set in the Attributes tab of interface builder

### DIFF
--- a/Classy/Additions/UIView+CASAdditions.h
+++ b/Classy/Additions/UIView+CASAdditions.h
@@ -12,6 +12,7 @@
 @interface UIView (CASAdditions) <CASStyleableItem>
 
 @property (nonatomic, weak, readwrite) id<CASStyleableItem> cas_alternativeParent;
+@property (nonatomic, copy) IBInspectable NSString *cas_styleClass;
 
 - (void)cas_setNeedsUpdateStylingForSubviews;
 


### PR DESCRIPTION
Adds the IBInspectable annotation to the cas_styleClass property in UIView+CASAdditions.h so you can set the the style class of a view in interface builder in the attributes tab.

![image](https://cloud.githubusercontent.com/assets/3374716/6672652/19a4a89e-cbcb-11e4-9177-ce45dd24338a.png)
