### PR TITLE
Fixes a crash caused by changing a hash table while it was being enumerated

### DIFF
--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -706,35 +706,41 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     return objectClassDescriptor;
 }
 
-#pragma mark - sceduling
+#pragma mark - scheduling
 
 - (void)updateScheduledItems {
-    for (id<CASStyleableItem> item in self.scheduledItems.allObjects.copy) {
-        if (!item) continue;
-        [item cas_updateStylingIfNeeded];
-    }
-
-    if (self.scheduledItems.allObjects.count == 0) {
-        [self.updateTimer invalidate];
-        self.updateTimer = nil;
+    @synchronized(self.scheduledItems) {
+        for (id<CASStyleableItem> item in self.scheduledItems.allObjects.copy) {
+            if (!item) continue;
+            [item cas_updateStylingIfNeeded];
+        }
+        
+        if (self.scheduledItems.allObjects.count == 0) {
+            [self.updateTimer invalidate];
+            self.updateTimer = nil;
+        }
     }
 }
 
 - (void)scheduleUpdateForItem:(id<CASStyleableItem>)item {
-    [self.scheduledItems addObject:item];
-
-    if (self.scheduledItems.allObjects.count && !self.updateTimer.isValid) {
-        self.updateTimer = [NSTimer timerWithTimeInterval:0.0 target:self selector:@selector(updateScheduledItems) userInfo:nil repeats:YES];
-        [NSRunLoop.mainRunLoop addTimer:self.updateTimer forMode:NSRunLoopCommonModes];
+    @synchronized(self.scheduledItems) {
+        [self.scheduledItems addObject:item];
+        
+        if (self.scheduledItems.allObjects.count && !self.updateTimer.isValid) {
+            self.updateTimer = [NSTimer timerWithTimeInterval:0.0 target:self selector:@selector(updateScheduledItems) userInfo:nil repeats:YES];
+            [NSRunLoop.mainRunLoop addTimer:self.updateTimer forMode:NSRunLoopCommonModes];
+        }
     }
 }
 
 - (void)unscheduleUpdateForItem:(id<CASStyleableItem>)item {
-    [self.scheduledItems removeObject:item];
-
-    if (self.scheduledItems.allObjects.count == 0) {
-        [self.updateTimer invalidate];
-        self.updateTimer = nil;
+    @synchronized(self.scheduledItems) {
+        [self.scheduledItems removeObject:item];
+        
+        if (self.scheduledItems.allObjects.count == 0) {
+            [self.updateTimer invalidate];
+            self.updateTimer = nil;
+        }
     }
 }
 


### PR DESCRIPTION
This problem happened when a thread was changing the scheduledItems hash table, while a timer triggered an
update in another thread. This issue was very rare but caused a crash with an exception like 

`'Collection <NSConcreteHashTable: 0x170134640> was mutated while being enumerated'`. 

It was solved by guarding the code parts that read and modify the hash table with a `@synchronized` block.