### PR TITLE
Added "System" font support with weight specification + styling per window

### DIFF
--- a/Carthage/Build
+++ b/Carthage/Build
@@ -1,0 +1,1 @@
+../../../../Carthage/Build

--- a/Classy/Additions/UIBarItem+CASAdditions.h
+++ b/Classy/Additions/UIBarItem+CASAdditions.h
@@ -10,7 +10,7 @@
 #import "CASStyleableItem.h"
 
 @interface UIBarItem (CASAdditions) <CASStyleableItem>
-
++ (void)bootstrapClassy;
 @property (nonatomic, weak, readwrite) id<CASStyleableItem> cas_parent;
 
 @end

--- a/Classy/Additions/UIBarItem+CASAdditions.m
+++ b/Classy/Additions/UIBarItem+CASAdditions.m
@@ -19,7 +19,7 @@
 CASSynthesize(weak, id<CASStyleableItem>, cas_parent, setCas_parent);
 
 
-+ (void)load {
++ (void)bootstrapClassy {
     [self cas_swizzleInstanceSelector:@selector(init)
                       withNewSelector:@selector(cas_init)];
 }

--- a/Classy/Additions/UINavigationItem+CASAdditions.h
+++ b/Classy/Additions/UINavigationItem+CASAdditions.h
@@ -9,5 +9,5 @@
 #import <UIKit/UIKit.h>
 
 @interface UINavigationItem (CASAdditions)
-
++ (void)bootstrapClassy;
 @end

--- a/Classy/Additions/UINavigationItem+CASAdditions.m
+++ b/Classy/Additions/UINavigationItem+CASAdditions.m
@@ -13,7 +13,7 @@
 
 @implementation UINavigationItem (CASAdditions)
 
-+ (void)load {
++ (void)bootstrapClassy {
     [self cas_swizzleInstanceSelector:@selector(setRightBarButtonItem:animated:) withNewSelector:@selector(cas_setRightBarButtonItem:animated:)];
     [self cas_swizzleInstanceSelector:@selector(setLeftBarButtonItem:animated:) withNewSelector:@selector(cas_setLeftBarButtonItem:animated:)];
     

--- a/Classy/Additions/UITextField+CASAdditions.h
+++ b/Classy/Additions/UITextField+CASAdditions.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 
 @interface UITextField (CASAdditions)
-
++ (void)bootstrapClassy;
 @property (nonatomic, assign) UIEdgeInsets cas_textEdgeInsets;
 
 @end

--- a/Classy/Additions/UITextField+CASAdditions.m
+++ b/Classy/Additions/UITextField+CASAdditions.m
@@ -12,7 +12,7 @@
 
 @implementation UITextField (CASAdditions)
 
-+ (void)load {
++ (void)bootstrapClassy {
     [self cas_swizzleInstanceSelector:@selector(textRectForBounds:)
                       withNewSelector:@selector(cas_textRectForBounds:)];
 

--- a/Classy/Additions/UIView+CASAdditions.h
+++ b/Classy/Additions/UIView+CASAdditions.h
@@ -10,6 +10,7 @@
 #import "CASStyleableItem.h"
 
 @interface UIView (CASAdditions) <CASStyleableItem>
++ (void)bootstrapClassy;
 
 @property (nonatomic, weak, readwrite) id<CASStyleableItem> cas_alternativeParent;
 @property (nonatomic, copy) IBInspectable NSString *cas_styleClass;

--- a/Classy/Additions/UIView+CASAdditions.m
+++ b/Classy/Additions/UIView+CASAdditions.m
@@ -21,7 +21,7 @@ static void *CASStyleHasBeenUpdatedKey = &CASStyleHasBeenUpdatedKey;
 
 CASSynthesize(weak, id<CASStyleableItem>, cas_alternativeParent, setCas_alternativeParent);
 
-+ (void)load {
++ (void)bootstrapClassy {
     [self cas_swizzleInstanceSelector:@selector(didMoveToWindow)
                       withNewSelector:@selector(cas_didMoveToWindow)];
 }

--- a/Classy/Additions/UIViewController+CASAdditions.h
+++ b/Classy/Additions/UIViewController+CASAdditions.h
@@ -10,5 +10,5 @@
 #import "CASStyleableItem.h"
 
 @interface UIViewController (CASAdditions) <CASStyleableItem>
-
++ (void)bootstrapClassy;
 @end

--- a/Classy/Additions/UIViewController+CASAdditions.m
+++ b/Classy/Additions/UIViewController+CASAdditions.m
@@ -19,7 +19,7 @@ static void *CASStyleHasBeenUpdatedKey = &CASStyleHasBeenUpdatedKey;
 
 @implementation UIViewController (CASAdditions)
 
-+ (void)load {
++ (void)bootstrapClassy {
     [self cas_swizzleInstanceSelector:@selector(setView:)
                       withNewSelector:@selector(cas_setView:)];
 }

--- a/Classy/Parser/CASStyleProperty.m
+++ b/Classy/Parser/CASStyleProperty.m
@@ -300,7 +300,26 @@
     } else {
         CGFloat fontSizeValue = [fontSize floatValue] ?: [UIFont systemFontSize];
         if (fontName) {
-            *font = [UIFont fontWithName:fontName size:fontSizeValue];
+            if ([fontName hasPrefix:@"System"]) {
+                
+                NSString *weightString = @"Regular";
+                NSArray *nameComponents = [fontName componentsSeparatedByString:@"-"];
+                if (nameComponents.count == 2) {
+                    weightString = nameComponents[1];
+                }
+                
+                if ([weightString isEqualToString:@"Regular"]) {
+                    *font = [UIFont systemFontOfSize:fontSizeValue];
+                }
+                else {
+                    UIFont *systemFont = [UIFont systemFontOfSize:fontSizeValue];
+                    UIFontDescriptor *descriptor = [UIFontDescriptor fontDescriptorWithFontAttributes:@{UIFontDescriptorFaceAttribute: weightString, UIFontDescriptorFamilyAttribute: systemFont.familyName}];
+                    *font = [UIFont fontWithDescriptor:descriptor size:fontSizeValue];
+                }
+            }
+            else {
+                *font = [UIFont fontWithName:fontName size:fontSizeValue];
+            }
         } else {
             *font = [UIFont systemFontOfSize:fontSizeValue];
         }

--- a/Classy/Parser/CASStyler.h
+++ b/Classy/Parser/CASStyler.h
@@ -31,6 +31,12 @@
 @property (nonatomic, copy) NSString *watchFilePath;
 
 /**
+ *  Windows to update views. 
+ *  Needed for live updates when UIApplication is not available (e.g. in Application Extensions)
+ */
+@property (nonatomic, strong) NSArray *targetWindows;
+
+/**
  *  Set file path location of styling data and report any errors
  *
  *  @param filePath The location of the style data

--- a/Classy/Parser/CASStyler.h
+++ b/Classy/Parser/CASStyler.h
@@ -12,6 +12,8 @@
 
 @interface CASStyler : NSObject
 
++ (void)bootstrapClassy;
+
 /**
  *  Singleton instance
  */

--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -114,11 +114,12 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     if (!self.filePath) return;
 
     // if stylesheet has already been loaded. reload stylesheet
+    NSString *filePath = _filePath;
     _filePath = nil;
-    self.filePath = _filePath;
+    self.filePath = filePath;
 
     // reapply styles
-    for (UIWindow *window in UIApplication.sharedApplication.windows) {
+    for (UIWindow *window in self.updatedWindows) {
         [self styleSubviewsOfView:window];
     }
 }
@@ -706,6 +707,18 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     return objectClassDescriptor;
 }
 
+- (NSArray *)updatedWindows
+{
+    NSMutableArray *windows = [NSMutableArray new];
+    if (UIApplication.sharedApplication.windows != nil) {
+        [windows addObjectsFromArray:UIApplication.sharedApplication.windows];
+    }
+    if (self.targetWindows) {
+        [windows addObjectsFromArray:self.targetWindows];
+    }
+    return windows;
+}
+
 #pragma mark - sceduling
 
 - (void)updateScheduledItems {
@@ -753,7 +766,7 @@ NSArray *ClassGetSubclasses(Class parentClass) {
             self.filePath = _watchFilePath;
 
             // reapply styles
-            for (UIWindow *window in UIApplication.sharedApplication.windows) {
+            for (UIWindow *window in self.updatedWindows) {
                 [self styleSubviewsOfView:window];
             }
         });

--- a/Classy/Parser/CASStyler.m
+++ b/Classy/Parser/CASStyler.m
@@ -1,3 +1,4 @@
+
 //
 //  CASStyler.m
 //  Classy
@@ -16,6 +17,12 @@
 #import "NSString+CASAdditions.h"
 #import "CASTextAttributes.h"
 #import "CASInvocation.h"
+
+#import "UIBarItem+CASAdditions.h"
+#import "UINavigationItem+CASAdditions.h"
+#import "UITextField+CASAdditions.h"
+#import "UIView+CASAdditions.h"
+#import "UIViewController+CASAdditions.h"
 #import <objc/runtime.h>
 
 // http://www.cocoawithlove.com/2010/01/getting-subclasses-of-objective-c-class.html
@@ -65,6 +72,14 @@ NSArray *ClassGetSubclasses(Class parentClass) {
     });
     
     return _defaultStyler;
+}
+
++ (void)bootstrapClassy {
+    [UIBarItem bootstrapClassy];
+    [UINavigationItem bootstrapClassy];
+    [UITextField bootstrapClassy];
+    [UIView bootstrapClassy];
+    [UIViewController bootstrapClassy];
 }
 
 - (id)init {

--- a/Example/ClassyExample/CASSimpleFormViewController.m
+++ b/Example/ClassyExample/CASSimpleFormViewController.m
@@ -31,6 +31,12 @@
     v.backgroundColor = [UIColor redColor];
     v.cas_styleClass = @"shadow-view";
     [self.view addSubview:v];
+    
+    UILabel *textLabel = [[UILabel alloc] initWithFrame:CGRectMake(50, 300, self.view.bounds.size.width - 100, 300)];
+    textLabel.text = @"Quick lazy Swift jumps over the lazy iOS/OS X developer's leg.";
+    textLabel.numberOfLines = 0;
+    textLabel.cas_styleClass = @"text-label";
+    [self.view addSubview:textLabel];
 }
 
 @end

--- a/Example/ClassyExample/Stylesheets/stylesheet.cas
+++ b/Example/ClassyExample/Stylesheets/stylesheet.cas
@@ -16,3 +16,8 @@ UIView.shadow-view {
         shadow-color black
         shadow-offset 0,0
 }
+
+UILabel.text-label {
+    font: System-Medium 30;
+    backgroundColor: white;
+}

--- a/Tests/Specs/Unit Tests/CASStylePropertySpec.m
+++ b/Tests/Specs/Unit Tests/CASStylePropertySpec.m
@@ -322,6 +322,26 @@ SpecBegin(CASStyleProperty)
     expect(font.pointSize).to.equal(24.0f);
 }
 
+- (void)testSystemFont {
+    NSArray *valueTokens = CASTokensFromString(@"System 12");
+    
+    CASStyleProperty *prop = [[CASStyleProperty alloc]initWithNameToken:nil valueTokens:valueTokens];
+    __block UIFont *font = nil;
+    expect([prop transformValuesToUIFont:&font]).to.beTruthy();
+    expect(font.familyName).to.equal([UIFont systemFontOfSize:12].familyName);
+    expect(font.pointSize).to.equal(12);
+}
+
+- (void)testSystemFontWeight {
+    NSArray *valueTokens = CASTokensFromString(@"System-Medium 18");
+    
+    CASStyleProperty *prop = [[CASStyleProperty alloc]initWithNameToken:nil valueTokens:valueTokens];
+    __block UIFont *font = nil;
+    expect([prop transformValuesToUIFont:&font]).to.beTruthy();
+    expect([font.fontDescriptor.fontAttributes[UIFontDescriptorNameAttribute] rangeOfString:@"Medium"].location != NSNotFound).to.beTruthy();
+    expect(font.pointSize).to.equal(18);
+}
+
 - (void)testPreferredFontForTextStyle {
     NSArray *valueTokens = CASTokensFromString(@"body");
     


### PR DESCRIPTION
Hey

With iOS 9 Apple rolls out new system fonts logic: system font is now San Francisco, and system font depends on size (until 19pt it is ".SFUI-Text", after it is ".SFUI-Display"). To cover that we imagined that Classy could support font name "System" and then automatically on iOS 8 choosen Helvetica and on iOS 9 appropriate SF font.

In package as well
Tests
Label test in the app
Styling per window